### PR TITLE
http_route prefix is /v1/ not /mv1/ in dao

### DIFF
--- a/UseCase51/README.md
+++ b/UseCase51/README.md
@@ -19,5 +19,5 @@ This project is configured to listen for requests to `use_case_51.local.nhds`. H
 
 ```
 curl -g -X GET \
-   'http://use_case_51.local.nhds/mv1/listing/?searchCriteria[filters][0][glue]=and&searchCriteria[filters][0][field]=id&searchCriteria[filters][0][condition]=lt&searchCriteria[filters][0][values][0]=20'
+   'http://use_case_51.local.nhds/v1/listing/?searchCriteria[filters][0][glue]=and&searchCriteria[filters][0][field]=id&searchCriteria[filters][0][condition]=lt&searchCriteria[filters][0][values][0]=20'
 ```


### PR DESCRIPTION
- http_route prefix is /v1/ not /mv1/ in [Listing.prefab.definition.yml](https://github.com/neighborhoods/PrefabFitness/blob/master/UseCase51/src/V1/Listing.prefab.definition.yml):
```yaml
http_route: /v1/listing/{searchCriteria:}
```